### PR TITLE
Small type fixes which also fixes build + clippy lints for Linux.

### DIFF
--- a/tun/src/apple/mod.rs
+++ b/tun/src/apple/mod.rs
@@ -38,7 +38,7 @@ impl TunInterface {
     }
 
     pub fn name(&self) -> Result<String> {
-        let mut buf = [0u8; libc::IFNAMSIZ];
+        let mut buf = [0i8; libc::IFNAMSIZ];
         let mut len = buf.len() as libc::socklen_t;
         syscall!(getsockopt(
             self.as_raw_fd(),

--- a/tun/src/linux.rs
+++ b/tun/src/linux.rs
@@ -15,13 +15,13 @@ impl TunInterface {
             .write(true)
             .open("/dev/net/tun")?;
 
-        let mut iff = libc::ifreq {
+        let iff = libc::ifreq {
             ifr_name: [0; libc::IFNAMSIZ],
             ifr_ifru: libc::__c_anonymous_ifr_ifru {
                 ifru_flags: (libc::IFF_TUN | libc::IFF_TUN_EXCL | libc::IFF_NO_PI) as i16,
             },
         };
-        unsafe { sys::tun_set_iff(file.as_raw_fd(), &mut iff)? };
+        unsafe { sys::tun_set_iff(file.as_raw_fd(), &iff)? };
 
         let inner = unsafe { socket2::Socket::from_raw_fd(file.into_raw_fd()) };
         Ok(TunInterface { inner })
@@ -50,7 +50,9 @@ mod sys {
     );
     ioctl_read_bad!(
         tun_get_iff,
-        request_code_read!(b'T', 210, size_of::<libc::c_int>()),
+        request_code_read!(b'T', 210, size_of::<libc::c_uint>()),
         libc::ifreq
     );
 }
+
+pub struct TunQueue;

--- a/tun/src/unix.rs
+++ b/tun/src/unix.rs
@@ -1,6 +1,6 @@
-use std::ffi::CStr;
+use std::ffi::{c_char, CStr};
 
-pub fn copy_if_name(buf: [u8; libc::IFNAMSIZ]) -> String {
+pub fn copy_if_name(buf: [c_char; libc::IFNAMSIZ]) -> String {
     // TODO: Switch to `CStr::from_bytes_until_nul` when stabilized
     unsafe {
         CStr::from_ptr(buf.as_ptr() as *const _)


### PR DESCRIPTION
Small type fixes:
1. According to [Linux's headers](https://github.com/torvalds/linux/blob/master/include/uapi/linux/if_tun.h), `TUNGETIFF` takes an unsigned int. (Doesn't actually change anything)
2. `copy_if_name` should take an int according to [this man page](https://man7.org/linux/man-pages/man2/getsockopt.2.html). This was causing the build to fail.