### PR TITLE
:sparkles: Create set_ipv6_addr & ipv6_addr (Linux)

### DIFF
--- a/tun/src/unix/linux/sys.rs
+++ b/tun/src/unix/linux/sys.rs
@@ -4,6 +4,7 @@ use std::mem::size_of;
 pub use libc::ifreq;
 pub use libc::sockaddr;
 pub use libc::sockaddr_in;
+pub use libc::sockaddr_in6;
 
 ioctl_write_ptr_bad!(
     tun_set_iff,
@@ -21,5 +22,6 @@ ioctl_read_bad!(if_get_mtu, libc::SIOCGIFMTU, libc::ifreq);
 ioctl_read_bad!(if_get_netmask, libc::SIOCGIFNETMASK, libc::ifreq);
 
 ioctl_write_ptr_bad!(if_set_addr, libc::SIOCSIFADDR, libc::ifreq);
+ioctl_write_ptr_bad!(if_set_addr6, libc::SIOCSIFADDR, libc::in6_ifreq);
 ioctl_write_ptr_bad!(if_set_mtu, libc::SIOCSIFMTU, libc::ifreq);
 ioctl_write_ptr_bad!(if_set_netmask, libc::SIOCSIFNETMASK, libc::ifreq);

--- a/tun/tests/configure.rs
+++ b/tun/tests/configure.rs
@@ -1,7 +1,7 @@
 use fehler::throws;
-use tun::TunInterface;
 use std::io::Error;
-use std::net::Ipv4Addr;
+use std::net::{Ipv4Addr, Ipv6Addr};
+use tun::TunInterface;
 
 #[test]
 #[throws]
@@ -19,4 +19,16 @@ fn test_set_get_ipv4() {
     let result = tun.ipv4_addr()?;
 
     assert_eq!(addr, result);
+}
+
+#[test]
+#[throws]
+fn test_set_get_ipv6() {
+    let tun = TunInterface::new()?;
+
+    let addr = Ipv6Addr::new(1, 1, 1, 1, 1, 1, 1, 1);
+    tun.set_ipv6_addr(addr)?;
+
+    // let result = tun.ipv6_addr()?;
+    // assert_eq!(addr, result);
 }


### PR DESCRIPTION
I'm fairly confident that set_ipv6_addr will work but I wasn't able to quite wrap my head around ipv4_addr so I'm less confident in ipv6_addr.