### PR TITLE
Add TunInterface implementations for MacOS

### DIFF
--- a/tun/src/unix/apple/mod.rs
+++ b/tun/src/unix/apple/mod.rs
@@ -83,4 +83,69 @@ impl TunInterface {
         let socket = Socket::new(Domain::IPV4, Type::DGRAM, None)?;
         perform(socket.as_raw_fd())?
     }
+
+    #[throws]
+    pub fn mtu(&self) -> i32 {
+        let mut iff = self.ifreq()?;
+        self.perform(|fd| unsafe { sys::if_get_mtu(fd, &mut iff) })?;
+        let mtu = unsafe { iff.ifr_ifru.ifru_mtu };
+
+        mtu
+    }
+
+    #[throws]
+    pub fn set_mtu(&self, mtu: i32) {
+        let mut iff = self.ifreq()?;
+        iff.ifr_ifru.ifru_mtu = mtu;
+        self.perform(|fd| unsafe { sys::if_set_mtu(fd, &iff) })?;
+    }
+
+    #[throws]
+    pub fn netmask(&self) -> Ipv4Addr {
+        let mut iff = self.ifreq()?;
+        self.perform(|fd| unsafe { sys::if_get_netmask(fd, &mut iff) })?;
+
+        let netmask =
+            unsafe { *(&iff.ifr_ifru.ifru_netmask as *const _ as *const sys::sockaddr_in) };
+
+        Ipv4Addr::from(u32::from_be(netmask.sin_addr.s_addr))
+    }
+
+    #[throws]
+    pub fn set_netmask(&self, addr: Ipv4Addr) {
+        let addr = SockAddr::from(SocketAddrV4::new(addr, 0));
+
+        let mut iff = self.ifreq()?;
+        iff.ifr_ifru.ifru_netmask = unsafe { *addr.as_ptr() };
+
+        self.perform(|fd| unsafe { sys::if_set_netmask(fd, &iff) })?;
+    }
+}
+
+mod test {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    #[test]
+    fn mtu() {
+        let interf = TunInterface::new().unwrap();
+
+        interf.set_mtu(500).unwrap();
+
+        assert_eq!(interf.mtu().unwrap(), 500);
+    }
+
+    #[test]
+    #[throws]
+    fn netmask() {
+        let interf = TunInterface::new()?;
+
+        let netmask = Ipv4Addr::new(255, 0, 0, 0);
+        let addr = Ipv4Addr::new(192, 168, 1, 1);
+
+        interf.set_ipv4_addr(addr)?;
+        interf.set_netmask(netmask)?;
+
+        assert_eq!(interf.netmask()?, netmask);
+    }
 }

--- a/tun/src/unix/apple/sys.rs
+++ b/tun/src/unix/apple/sys.rs
@@ -5,7 +5,10 @@ pub use libc::{
     c_void, sockaddr_ctl, sockaddr_in, socklen_t, AF_SYSTEM, AF_SYS_CONTROL, IFNAMSIZ,
     SYSPROTO_CONTROL,
 };
-use nix::{ioctl_read_bad, ioctl_readwrite, ioctl_write_ptr_bad, request_code_write};
+use nix::{
+    ioctl_read_bad, ioctl_readwrite, ioctl_write_ptr_bad, request_code_readwrite,
+    request_code_write,
+};
 
 pub const UTUN_CONTROL_NAME: &str = "com.apple.net.utun_control";
 pub const UTUN_OPT_IFNAME: libc::c_int = 2;
@@ -40,6 +43,7 @@ pub union ifr_ifru {
     pub ifru_addr: sockaddr,
     pub ifru_dstaddr: sockaddr,
     pub ifru_broadaddr: sockaddr,
+    pub ifru_netmask: sockaddr,
     pub ifru_flags: c_short,
     pub ifru_metric: c_int,
     pub ifru_mtu: c_int,
@@ -62,6 +66,10 @@ pub struct ifreq {
 }
 
 pub const SIOCSIFADDR: c_ulong = request_code_write!(b'i', 12, mem::size_of::<ifreq>());
+pub const SIOCGIFMTU: c_ulong = request_code_readwrite!(b'i', 51, mem::size_of::<ifreq>());
+pub const SIOCSIFMTU: c_ulong = request_code_write!(b'i', 52, mem::size_of::<ifreq>());
+pub const SIOCGIFNETMASK: c_ulong = request_code_readwrite!(b'i', 37, mem::size_of::<ifreq>());
+pub const SIOCSIFNETMASK: c_ulong = request_code_write!(b'i', 22, mem::size_of::<ifreq>());
 
 #[macro_export]
 macro_rules! syscall {
@@ -77,4 +85,8 @@ pub use syscall;
 
 ioctl_readwrite!(resolve_ctl_info, b'N', 3, ctl_info);
 ioctl_read_bad!(if_get_addr, libc::SIOCGIFADDR, ifreq);
+ioctl_read_bad!(if_get_mtu, SIOCGIFMTU, ifreq);
+ioctl_read_bad!(if_get_netmask, SIOCGIFNETMASK, ifreq);
 ioctl_write_ptr_bad!(if_set_addr, SIOCSIFADDR, ifreq);
+ioctl_write_ptr_bad!(if_set_mtu, SIOCSIFMTU, ifreq);
+ioctl_write_ptr_bad!(if_set_netmask, SIOCSIFNETMASK, ifreq);


### PR DESCRIPTION
#45

Most of the code is directly copied from the linux implementation, the `SIOCGIFMTU` and `SIOCSIFMTU` codes are copied from [here](https://github.com/dcuddeback/ioctl-rs/blob/89fcf110e9c286f4349895b4e08a4ca9c039e1a4/src/os/macos.rs#L60-L61)

P.S. the six-year-old crate [ioctl-rs](https://github.com/dcuddeback/ioctl-rs/) seems to contain the correct information about MacOS ioctl codes that are not included in `libc`, perhaps consider using that for the macos implementation?