### PR TITLE
Add cfg-test for test modules

### DIFF
--- a/tun/src/unix/apple/mod.rs
+++ b/tun/src/unix/apple/mod.rs
@@ -122,6 +122,7 @@ impl TunInterface {
     }
 }
 
+#[cfg(test)]
 mod test {
     use super::*;
     use std::net::Ipv4Addr;

--- a/tun/src/unix/linux/mod.rs
+++ b/tun/src/unix/linux/mod.rs
@@ -120,6 +120,7 @@ impl TunInterface {
     }
 }
 
+#[cfg(test)]
 mod test {
     use super::TunInterface;
     use std::net::Ipv4Addr;


### PR DESCRIPTION
This adds `#[cfg(test)]` statement for test modules. 
Without it, rustc will mark import statements within test modules as unused, which could cause necessary imports being removed if we run something like `cargo clippy --fix`
