### PR TITLE
Set/get broadcast address in TunInterface

### DIFF
--- a/tun/src/unix/linux/sys.rs
+++ b/tun/src/unix/linux/sys.rs
@@ -18,10 +18,12 @@ ioctl_read_bad!(
 );
 ioctl_read_bad!(if_get_index, libc::SIOCGIFINDEX, libc::ifreq);
 ioctl_read_bad!(if_get_addr, libc::SIOCGIFADDR, libc::ifreq);
+ioctl_read_bad!(if_get_brdaddr, libc::SIOCGIFBRDADDR, libc::ifreq);
 ioctl_read_bad!(if_get_mtu, libc::SIOCGIFMTU, libc::ifreq);
 ioctl_read_bad!(if_get_netmask, libc::SIOCGIFNETMASK, libc::ifreq);
 
 ioctl_write_ptr_bad!(if_set_addr, libc::SIOCSIFADDR, libc::ifreq);
 ioctl_write_ptr_bad!(if_set_addr6, libc::SIOCSIFADDR, libc::in6_ifreq);
+ioctl_write_ptr_bad!(if_set_brdaddr, libc::SIOCSIFBRDADDR, libc::ifreq);
 ioctl_write_ptr_bad!(if_set_mtu, libc::SIOCSIFMTU, libc::ifreq);
 ioctl_write_ptr_bad!(if_set_netmask, libc::SIOCSIFNETMASK, libc::ifreq);

--- a/tun/tests/configure.rs
+++ b/tun/tests/configure.rs
@@ -11,6 +11,21 @@ fn test_create() {
 
 #[test]
 #[throws]
+#[cfg(not(any(target_os = "windows", target_vendor = "apple")))]
+fn test_set_get_broadcast_addr() {
+    let tun = TunInterface::new()?;
+    let addr = Ipv4Addr::new(10, 0, 0, 1);
+    tun.set_ipv4_addr(addr)?;
+
+    let broadcast_addr = Ipv4Addr::new(255, 255, 255, 0);
+    tun.set_broadcast_addr(broadcast_addr)?;
+    let result = tun.broadcast_addr()?;
+
+    assert_eq!(broadcast_addr, result);
+}
+
+#[test]
+#[throws]
 #[cfg(not(target_os = "windows"))]
 fn test_set_get_ipv4() {
     let tun = TunInterface::new()?;


### PR DESCRIPTION
Modelled after TunInterface's IPV4 logic; uses SIOCGIFBRDADDR & SIOCSIFBRDADDR. View https://man7.org/linux/man-pages/man7/netdevice.7.html.