### PR TITLE
Use tracing for logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anstream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,6 +94,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,6 +121,29 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bindgen"
+version = "0.59.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "clap 2.34.0",
+ "env_logger",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "which",
+]
 
 [[package]]
 name = "bindgen"
@@ -150,12 +193,16 @@ checksum = "3c6ed94e98ecff0c12dd1b04c15ec0d7d9458ca8fe806cea6f12954efe74c63b"
 name = "burrow"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "caps",
- "clap",
- "env_logger",
- "log",
+ "clap 4.3.2",
  "nix",
  "tokio",
+ "tracing",
+ "tracing-journald",
+ "tracing-log",
+ "tracing-oslog",
+ "tracing-subscriber",
  "tun",
 ]
 
@@ -248,6 +295,21 @@ dependencies = [
 
 [[package]]
 name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim 0.8.0",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "clap"
 version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "401a4694d2bf92537b6867d94de48c4842089645fdcdf6c71865b175d836e9c2"
@@ -267,7 +329,7 @@ dependencies = [
  "anstyle",
  "bitflags",
  "clap_lex",
- "strsim",
+ "strsim 0.10.0",
 ]
 
 [[package]]
@@ -381,12 +443,12 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.10.0"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
+ "atty",
  "humantime",
- "is-terminal",
  "log",
  "regex",
  "termcolor",
@@ -620,6 +682,15 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
@@ -751,7 +822,7 @@ version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.1",
  "libc",
  "windows-sys 0.48.0",
 ]
@@ -768,7 +839,7 @@ version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.1",
  "io-lifetimes",
  "rustix",
  "windows-sys 0.48.0",
@@ -831,6 +902,16 @@ name = "linux-raw-sys"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
+
+[[package]]
+name = "lock_api"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -952,6 +1033,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1005,6 +1096,37 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -1093,6 +1215,15 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -1193,6 +1324,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "security-framework"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1278,6 +1415,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,6 +1437,12 @@ checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "socket2"
@@ -1323,6 +1475,12 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "strsim"
@@ -1366,7 +1524,7 @@ checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
 dependencies = [
  "cfg-if",
  "fastrand",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "rustix",
  "windows-sys 0.45.0",
 ]
@@ -1378,6 +1536,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1398,6 +1565,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.15",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+dependencies = [
+ "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -1496,7 +1673,19 @@ checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1506,6 +1695,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-journald"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba316a74e8fc3c3896a850dba2375928a9fa171b085ecddfc7c054d39970f3fd"
+dependencies = [
+ "libc",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-oslog"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bc58223383423483e4bc056c7e7b3f77bdee924a9d33834112c69ead06dc847"
+dependencies = [
+ "bindgen 0.59.2",
+ "cc",
+ "cfg-if",
+ "fnv",
+ "once_cell",
+ "parking_lot",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1519,20 +1761,20 @@ name = "tun"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bindgen",
+ "bindgen 0.65.1",
  "byteorder",
  "fehler",
  "futures",
  "lazy_static",
  "libc",
  "libloading",
- "log",
  "nix",
  "reqwest",
  "socket2",
  "ssri",
  "tempfile",
  "tokio",
+ "tracing",
  "widestring",
  "windows",
  "zip",
@@ -1589,10 +1831,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/burrow/Cargo.toml
+++ b/burrow/Cargo.toml
@@ -7,11 +7,15 @@ edition = "2021"
 crate-type = ["lib", "staticlib"]
 
 [dependencies]
+anyhow = "1.0"
 tokio = { version = "1.21", features = ["rt", "macros"] }
 tun = { version = "0.1", path = "../tun" }
 clap = { version = "4.3.2", features = ["derive"] }
-env_logger = "0.10"
-log = "0.4"
+tracing = "0.1"
+tracing-log = "0.1"
+tracing-journald = "0.3"
+tracing-oslog = "0.1"
+tracing-subscriber = "0.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 caps = "0.5.5"

--- a/burrow/src/ensureroot.rs
+++ b/burrow/src/ensureroot.rs
@@ -1,5 +1,8 @@
+use tracing::instrument;
+
 // Check capabilities on Linux
 #[cfg(target_os = "linux")]
+#[instrument]
 pub fn ensure_root() {
     use caps::{has_cap, CapSet, Capability};
 
@@ -19,6 +22,7 @@ pub fn ensure_root() {
 
 // Check for root user on macOS
 #[cfg(target_vendor = "apple")]
+#[instrument]
 pub fn ensure_root() {
     use nix::unistd::Uid;
 
@@ -30,6 +34,7 @@ pub fn ensure_root() {
 }
 
 #[cfg(target_family = "windows")]
+#[instrument]
 pub fn ensure_root() {
     todo!()
 }

--- a/burrow/src/lib.rs
+++ b/burrow/src/lib.rs
@@ -1,1 +1,2 @@
+#![deny(missing_debug_implementations)]
 pub mod ensureroot;

--- a/burrow/src/main.rs
+++ b/burrow/src/main.rs
@@ -1,6 +1,12 @@
+use anyhow::Context;
 use clap::{Args, Parser, Subcommand};
-use tokio::io::Result;
+use tracing::instrument;
+
+use tracing_log::LogTracer;
+use tracing_oslog::OsLogger;
+use tracing_subscriber::{prelude::*, FmtSubscriber};
 use tun::TunInterface;
+
 
 #[derive(Parser)]
 #[command(name = "Burrow")]
@@ -27,23 +33,51 @@ enum Commands {
 #[derive(Args)]
 struct StartArgs {}
 
-async fn try_main() -> Result<()> {
+#[instrument]
+async fn try_main() -> anyhow::Result<()> {
+    LogTracer::init().context("Failed to initialize LogTracer")?;
     burrow::ensureroot::ensure_root();
 
+	if cfg!(target_os = "linux") || cfg!(target_vendor = "apple") {
+    	let maybe_layer = system_log()?;
+    	if let Some(layer) = maybe_layer {
+        	let logger = layer.with_subscriber(FmtSubscriber::new());
+        	tracing::subscriber::set_global_default(logger).context("Failed to set the global tracing subscriber")?;
+    	}
+	}
+	
     let iface = TunInterface::new()?;
-    println!("{:?}", iface.name());
+    tracing::info!(interface_name = ?iface.name());
 
     Ok(())
 }
 
 #[tokio::main(flavor = "current_thread")]
-async fn main() {
+async fn main() -> anyhow::Result<()> {
     println!("Platform: {}", std::env::consts::OS);
 
     let cli = Cli::parse();
     match &cli.command {
         Commands::Start(..) => {
-            try_main().await.unwrap();
+            try_main().await?;
         }
     }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn system_log() -> anyhow::Result<Option<tracing_journald::Layer>> {
+    let maybe_journald = tracing_journald::layer();
+    match maybe_journald {
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            tracing::trace!("journald not found");
+            Ok(None)
+        },
+        _ => Ok(Some(maybe_journald?))
+    }
+}
+
+#[cfg(target_vendor = "apple")]
+fn system_log() -> anyhow::Result<Option<OsLogger>> {
+    Ok(Some(OsLogger::new("com.hackclub.burrow", "default")))
 }

--- a/tun/Cargo.toml
+++ b/tun/Cargo.toml
@@ -10,7 +10,7 @@ nix = { version = "0.26", features = ["ioctl"] }
 socket2 = "0.4"
 tokio = { version = "1.28", features = [] }
 byteorder = "1.4"
-log = "0.4"
+tracing = "0.1"
 
 futures = { version = "0.3.28", optional = true }
 

--- a/tun/src/lib.rs
+++ b/tun/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(missing_debug_implementations)]
+
 #[cfg(target_os = "windows")]
 #[path = "windows/mod.rs"]
 mod imp;

--- a/tun/src/options.rs
+++ b/tun/src/options.rs
@@ -3,7 +3,7 @@ use std::io::Error;
 
 use super::TunInterface;
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct TunOptions {
     /// (Windows + Linux) Name the tun interface.
     pub(crate) name: Option<String>,

--- a/tun/src/tokio/mod.rs
+++ b/tun/src/tokio/mod.rs
@@ -1,17 +1,21 @@
 use std::io;
 use tokio::io::unix::AsyncFd;
+use tracing::instrument;
 
+#[derive(Debug)]
 pub struct TunInterface {
     inner: AsyncFd<crate::TunInterface>,
 }
 
 impl TunInterface {
+    #[instrument]
     pub fn new(tun: crate::TunInterface) -> io::Result<Self> {
         Ok(Self {
             inner: AsyncFd::new(tun)?,
         })
     }
 
+    #[instrument]
     pub async fn write(&self, buf: &[u8]) -> io::Result<usize> {
         loop {
             let mut guard = self.inner.writable().await?;
@@ -22,6 +26,7 @@ impl TunInterface {
         }
     }
 
+    #[instrument]
     pub async fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         loop {
             let mut guard = self.inner.readable_mut().await?;

--- a/tun/src/unix/mod.rs
+++ b/tun/src/unix/mod.rs
@@ -2,6 +2,7 @@ use std::{
     io::{Error, Read},
     os::fd::{AsRawFd, FromRawFd, IntoRawFd, RawFd},
 };
+use tracing::instrument;
 
 use super::TunOptions;
 
@@ -41,11 +42,13 @@ impl IntoRawFd for TunInterface {
 
 impl TunInterface {
     #[throws]
+    #[instrument]
     pub fn recv(&mut self, buf: &mut [u8]) -> usize {
         self.socket.read(buf)?
     }
 }
 
+#[instrument]
 pub fn ifname_to_string(buf: [libc::c_char; libc::IFNAMSIZ]) -> String {
     // TODO: Switch to `CStr::from_bytes_until_nul` when stabilized
     unsafe {
@@ -56,6 +59,7 @@ pub fn ifname_to_string(buf: [libc::c_char; libc::IFNAMSIZ]) -> String {
     }
 }
 
+#[instrument]
 pub fn string_to_ifname(name: &str) -> [libc::c_char; libc::IFNAMSIZ] {
     let mut buf = [0 as libc::c_char; libc::IFNAMSIZ];
     let len = name.len().min(buf.len());

--- a/tun/src/unix/queue.rs
+++ b/tun/src/unix/queue.rs
@@ -5,15 +5,18 @@ use std::{
     mem::MaybeUninit,
     os::unix::io::{AsRawFd, IntoRawFd, RawFd},
 };
+use tracing::instrument;
 
 use crate::TunInterface;
 
+#[derive(Debug)]
 pub struct TunQueue {
     socket: socket2::Socket,
 }
 
 impl TunQueue {
     #[throws]
+    #[instrument]
     pub fn recv(&self, buf: &mut [MaybeUninit<u8>]) -> usize {
         self.socket.recv(buf)?
     }


### PR DESCRIPTION
Attempts progress on #125

Currently, this PR switches logging to the tracing crate, and uses system loggers and tracing's stdout logger on mac and linux. I'm unable to test if it actually works on mac because I don't have access to one. Additionally, everything is instrumented with the #[instrument] macro so we have spans for free. Haven't figured out how to log to a system log storage yet on windows, and the linux implementation depends on systemd existing. Adding more logging to tun still needs to be completed.