### PR TITLE
Created simple burrow UI for iOS

### DIFF
--- a/Apple/App/BurrowApp.swift
+++ b/Apple/App/BurrowApp.swift
@@ -15,7 +15,7 @@ struct BurrowApp: App {
 
     var body: some Scene {
         WindowGroup {
-            TunnelView()
+            TunnelView(tunnel: Self.tunnel)
         }
     }
 }

--- a/Apple/App/TunnelView.swift
+++ b/Apple/App/TunnelView.swift
@@ -1,36 +1,56 @@
 import SwiftUI
 
 struct TunnelView: View {
-//    @ObservedObject var tunnel: Tunnel
+    @ObservedObject var tunnel: Tunnel
+    @State var useBurrow = false
+    
+
 
     var body: some View {
+        #if os(iOS)
+        Text("Burrow")
+            .font(.largeTitle)
+            .fontWeight(.heavy)
+        VStack {
+            switch tunnel.status {
+            case .connecting, .disconnecting:
+                ProgressView().controlSize(.large).padding()
+            case .permissionRequired:
+                var useBurrow = false
+                Button("Configure VPN", action: configure).buttonStyle(.borderedProminent).tint(.red).padding()
+            default:
+// for someone else to do: clean up my code and make the toggle VERY large that it's juicy. - R. Ruiz (allthesquares)
+                Toggle("", isOn: $useBurrow)
+                    .disabled(tunnel.status == .unknown || tunnel.status == .configurationReadWriteFailed || tunnel.status == .invalid)
+                    .labelsHidden()
+                    .controlSize(.large)
+                    .padding()
+                    .toggleStyle(SwitchToggleStyle(tint: .red))
+                    .onChange(of: useBurrow) { value in
+                    if value == true {
+                        start()
+                    } else {
+                        stop()
+                    }
+                    }
+            }
+            Text(verbatim: tunnel.status.description)
+        }
+            .task { await tunnel.update() }
+        #else
         EmptyView()
-//        VStack {
-//            Text(verbatim: tunnel.status.description)
-//            switch tunnel.status {
-//            case .connected:
-//                Button("Disconnect", action: stop)
-//            case .permissionRequired:
-//                Button("Allow", action: configure)
-//            case .disconnected:
-//                Button("Start", action: start)
-//            default:
-//                EmptyView()
-//            }
-//        }
-//        .task { await tunnel.update() }
-//        .padding()
+        #endif
     }
 
-//    private func start() {
-//        try? tunnel.start()
-//    }
-//
-//    private func stop() {
-//        tunnel.stop()
-//    }
-//
-//    private func configure() {
-//        Task { try await tunnel.configure() }
-//    }
+    private func start() {
+        try? tunnel.start()
+    }
+
+    private func stop() {
+        tunnel.stop()
+    }
+
+    private func configure() {
+        Task { try await tunnel.configure() }
+    }
 }

--- a/Apple/Burrow.xcodeproj/project.pbxproj
+++ b/Apple/Burrow.xcodeproj/project.pbxproj
@@ -345,6 +345,9 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D020F66229E4A6E5002790F6 /* NetworkExtension.xcconfig */;
 			buildSettings = {
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};
@@ -352,6 +355,9 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D020F66229E4A6E5002790F6 /* NetworkExtension.xcconfig */;
 			buildSettings = {
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Edited the existing view so that if running on an iOS device it would provide a basic UI with a toggle switch that will allow the user to connect/disconnect from the VPN

In the iOS app, the toggle does not display if the user did not configure the VPN (or is using the app for the first time), and instead a button will show up to configure the VPN in Settings.