### PR TITLE
Bump Rust version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/rust:1.70.0-slim-bookworm AS builder
+FROM docker.io/library/rust:1.74.0-slim-bookworm AS builder
 
 ARG TARGETPLATFORM
 ARG LLVM_VERSION=16


### PR DESCRIPTION
clap-rs recently bumped their MSRV to 1.74 breaking the docker build.